### PR TITLE
chore: lint, update deps

### DIFF
--- a/latest-linker.js
+++ b/latest-linker.js
@@ -2,126 +2,150 @@
 
 'use strict'
 
-const fs       = require('fs')
-    , path     = require('path')
-    , semver   = require('semver')
-    , map      = require('map-async')
+const fs = require('fs')
+const path = require('path')
+const semver = require('semver')
+const map = require('map-async')
 
-    , ltsNames = {
-          4 : 'argon'
-        , 6 : 'boron'
-        , 8 : 'carbon'
-        , 10 : 'dubnium'
-        , 12 : 'erbium'
-      }
+const ltsNames = {
+  4: 'argon',
+  6: 'boron',
+  8: 'carbon',
+  10: 'dubnium',
+  12: 'erbium'
+}
 
-if (process.argv.length < 3)
+if (process.argv.length < 3) {
   throw new Error('Usage: latest-linker.js <downloads directory> [docs directory]')
+}
 
 const dir = path.resolve(process.argv[2])
-    , docsDir = process.argv[3] && path.resolve(process.argv[3])
+const docsDir = process.argv[3] && path.resolve(process.argv[3])
 
-if (!fs.statSync(dir).isDirectory())
+if (!fs.statSync(dir).isDirectory()) {
   throw new Error('Usage: latest-linker.js <downloads directory> [docs directory]')
+}
 
-if (docsDir && !fs.statSync(docsDir).isDirectory())
+if (docsDir && !fs.statSync(docsDir).isDirectory()) {
   throw new Error('Usage: latest-linker.js <downloads directory> [docs directory]')
-
+}
 
 map(
-    fs.readdirSync(dir).map((d) => path.join(dir, d))
-  , (d, callback) => fs.stat(d, (err, stat) => callback(null, { d: d, stat: stat }))
-  , afterMap
+  fs.readdirSync(dir).map((d) => path.join(dir, d)),
+  (d, callback) => fs.stat(d, (_, stat) => callback(null, { d, stat })),
+  afterMap
 )
 
-
 function afterMap (err, allDirs) {
-  if (err)
+  if (err) {
     throw err
+  }
 
   allDirs = allDirs.filter((d) => d.stat && d.stat.isDirectory())
-                   .map((d) => path.basename(d.d))
-                   .map((d) => { try { return semver(d) } catch (e) {} })
-                   .filter(Boolean)
+    .map((d) => path.basename(d.d))
+    .map((d) => {
+      try {
+        return semver(d)
+      } catch (e) {}
+    })
+    .filter(Boolean)
 
   makeDocsLinks(allDirs.map((v) => v.raw))
 
-  let dirs = allDirs.filter((d) => semver.satisfies(d, '~0.10 || ~0.12 || >= 1.0'))
-                    .map((d) => d.raw)
+  const dirs = allDirs.filter((d) => semver.satisfies(d, '~0.10 || ~0.12 || >= 1.0'))
+    .map((d) => d.raw)
 
   dirs.sort((d1, d2) => semver.compare(d1, d2))
 
   link('0.10', dirs)
   link(0.12, dirs)
 
-  for (let i = 1;; i++)
-    if (!link(i, dirs) && i >= 4) break
+  for (let i = 1; ; i++) {
+    if (!link(i, dirs) && i >= 4) {
+      break
+    }
+  }
 
-  let max   = link(null, dirs)
-    , tbreg = new RegExp(`(\\w+)-${max}.tar.gz`)
+  const max = link(null, dirs)
+  const tbreg = new RegExp(`(\\w+)-${max}.tar.gz`)
 
   let tarball = fs.readdirSync(path.join(dir, 'latest'))
-                  .filter((f) => tbreg.test(f))
+    .filter((f) => tbreg.test(f))
 
-  if (tarball.length != 1)
+  if (tarball.length !== 1) {
     throw new Error('Could not find latest.tar.gz')
+  }
 
   tarball = tarball[0]
-  let name = tarball.match(tbreg)[1]
-  let dst = path.join(dir, `${name}-latest.tar.gz`)
-  try { fs.unlinkSync(dst) } catch (e) {}
+  const name = tarball.match(tbreg)[1]
+  const dst = path.join(dir, `${name}-latest.tar.gz`)
+  try {
+    fs.unlinkSync(dst)
+  } catch (e) {}
   fs.symlinkSync(path.join(dir, 'latest', tarball), dst)
 }
 
-
 function makeDocsLinks (versions) {
-  if (!docsDir)
+  if (!docsDir) {
     return
+  }
 
   versions.forEach((version) => {
-    let src = path.join(dir, version, 'docs')
-      , dst = path.join(docsDir, version)
+    const src = path.join(dir, version, 'docs')
+    const dst = path.join(docsDir, version)
 
     fs.stat(src, (err, stat) => {
-      if (err || !stat.isDirectory())
+      if (err || !stat.isDirectory()) {
         return
+      }
 
       fs.unlink(dst, () => {
-        fs.symlink(src, dst, (err) => { if (err) throw err })
+        fs.symlink(src, dst, (err) => {
+          if (err) {
+            throw err
+          }
+        })
       })
     })
   })
 }
 
-
 function link (version, dirs) {
-  let line  = version && `${version}.x`
-    , range = version ? `${Number(version) < 1 ? '~' : '^'}${line}` : '*'
-    , max   = semver.maxSatisfying(dirs, range)
+  const line = version && `${version}.x`
+  const range = version ? `${Number(version) < 1 ? '~' : '^'}${line}` : '*'
+  const max = semver.maxSatisfying(dirs, range)
 
-  if (!max) return false
+  if (!max) {
+    return false
+  }
 
   function symlink (name) {
-    let dst = path.join(dir, name)
-      , src = path.join(dir, max)
+    const dst = path.join(dir, name)
+    const src = path.join(dir, max)
 
-    try { fs.unlinkSync(dst) } catch (e) {}
+    try {
+      fs.unlinkSync(dst)
+    } catch (e) {}
     fs.symlinkSync(src, dst)
 
-    if (!docsDir)
+    if (!docsDir) {
       return
+    }
 
-    let dsrc = path.join(dir, max, 'docs')
-      , ddst = path.join(docsDir, name)
+    const dsrc = path.join(dir, max, 'docs')
+    const ddst = path.join(docsDir, name)
 
-    try { fs.unlinkSync(ddst) } catch (e) {}
+    try {
+      fs.unlinkSync(ddst)
+    } catch (e) {}
     fs.symlinkSync(dsrc, ddst)
   }
 
   if (line) {
     symlink(`latest-v${line}`)
-    if (ltsNames[version])
+    if (ltsNames[version]) {
       symlink(`latest-${ltsNames[version]}`)
+    }
   } else {
     symlink('latest')
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An application to create latest-X symlinks at https://nodejs.org/download/release/ after each new release",
   "main": "latest-linker.js",
   "scripts": {
-    "test": ""
+		"lint": "standard",
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -13,11 +14,14 @@
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "MIT",
   "dependencies": {
-    "map-async": "~0.1.1",
-    "semver": "~5.3.0"
+    "map-async": "^0.1.1",
+    "semver": "^7.3.2"
   },
   "bin": {
     "nodejs-latest-linker": "./latest-linker.js"
   },
-  "preferGlobal": true
+  "preferGlobal": true,
+  "devDependencies": {
+    "standard": "^14.3.4"
+  }
 }


### PR DESCRIPTION
only meaningful change here is a bump to semver@7 and the breaking changes between what we had and this new version are in `semver.intersects()` and node version support, so we're not impacted.