### PR TITLE
add Node.js 14 LTS fermium

### DIFF
--- a/latest-linker.js
+++ b/latest-linker.js
@@ -12,7 +12,8 @@ const ltsNames = {
   6: 'boron',
   8: 'carbon',
   10: 'dubnium',
-  12: 'erbium'
+  12: 'erbium',
+  14: 'fermium'
 }
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/35746

This should go live just before v14.15.0 is released as we do not want to link `latest-fermium` to v14.14.0.