### PR TITLE
Add Node.js 16 gallium

### DIFF
--- a/latest-linker.js
+++ b/latest-linker.js
@@ -13,7 +13,8 @@ const ltsNames = {
   8: 'carbon',
   10: 'dubnium',
   12: 'erbium',
-  14: 'fermium'
+  14: 'fermium',
+  16: 'gallium'
 }
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/Release/blob/main/CODENAMES.md

---

Node.js 16 transitions to LTS on 2021-10-26.