### PR TITLE
change package npm destination

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nodejs-latest-linker",
-  "version": "1.7.0",
+  "name": "@node-core/latest-linker",
+  "version": "1.0.0",
   "description": "An application to create latest-X symlinks at https://nodejs.org/download/release/ after each new release",
   "main": "latest-linker.js",
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/nodejs/nodejs-latest-linker/issues/13

I've added the required secret to the repo settings
once this goes through, the needed steps are:
- [ ] update https://github.com/search?q=repo%3Anodejs%2Fbuild+nodejs-latest-linker&type=code and manually deploy to the dist server
- [ ] update https://github.com/search?q=repo%3Anodejs%2Frelease-cloudflare-worker%20nodejs-latest-linker&type=code
- [ ] run `npm deprecate nodejs-latest-linker "This package has been renamed to @node-core/latest-linker"`